### PR TITLE
Update CPS supplemental poverty research filename generator by one year

### DIFF
--- a/Current Population Survey/download all microdata.R
+++ b/Current Population Survey/download all microdata.R
@@ -728,7 +728,7 @@ for ( year in cps.years.to.download ){
 			paste0( 
 			"http://www.census.gov/housing/povmeas/spmresearch/spmresearch" , 
 			floor( year - 1 ) , 
-			if ( year == 2014.38 ) "_redes" else if ( year >= 2015 ) "" else "new" ,
+			if ( year == 2014.38 ) "_redes" else if ( year >= 2016 ) "" else "new" ,
 			".sas7bdat" 
 		)
 		


### PR DESCRIPTION
Census has changed name of spmresearch2014.sas7bdat to spmresearch2014***new***.sas7bdat
See https://www.census.gov/housing/povmeas/spmresearch/
- "year" = 2015, "year - 1" filename = spmresearch2014new.sas7bdat
- "year" = 2016, "year - 1" filename = spmresearch2015.sas7bdat