### PR TITLE
Update 55-psid.Rmd

### DIFF
--- a/55-psid.Rmd
+++ b/55-psid.Rmd
@@ -40,7 +40,7 @@ lodown( "psid" , psid_cat ,
 	your_password = "password" )
 ```
 
-## Analysis Examples with the `survey` library \ {-}
+## Analysis Examples with the `survey` library {-}
 
 Construct a complex sample survey design:
 
@@ -74,6 +74,8 @@ ind_variables_to_keep <-
 		'er30002' , 	# 1968 person number
 		'er31997' ,		# primary sampling unit variable
 		'er31996' ,		# stratification variable
+		'er33801' ,     # interview number, 2005
+                'er34301' ,     # interview number, 2015
 		'er33802' ,		# sequence number, 2005
 		'er34302' , 	# sequence number, 2015
 		'er32000' ,		# sex
@@ -115,7 +117,7 @@ ind_fam_2005 <-
 	merge( 
 		individual_df , 
 		family_2005_df , 
-		by.x = 'er33802' , 
+		by.x = 'er33801' , 
 		by.y = 'er25002' 
 	)
 
@@ -123,7 +125,7 @@ ind_fam_2015 <-
 	merge( 
 		individual_df , 
 		family_2015_df , 
-		by.x = 'er34302' , 
+		by.x = 'er34301' , 
 		by.y = 'er60002' 
 	)
 
@@ -327,7 +329,7 @@ glm_result <-
 summary( glm_result )
 ```
 
-## Analysis Examples with `srvyr` \ {-}
+## Analysis Examples with `srvyr` {-}
 
 The R `srvyr` library calculates summary statistics from survey data, such as the mean, total or quantile using [dplyr](https://github.com/tidyverse/dplyr/)-like syntax. [srvyr](https://github.com/gergness/srvyr) allows for the use of many verbs, such as `summarize`, `group_by`, and `mutate`, the convenience of pipe-able functions, the `tidyverse` style of non-standard evaluation and more consistent return types than the `survey` package. [This vignette](https://cran.r-project.org/web/packages/srvyr/vignettes/srvyr-vs-survey.html) details the available features. As a starting point for PSID users, this code replicates previously-presented examples:
 


### PR DESCRIPTION
According to the PSID documentation, you should be using the “[Year] Interview Number” from the cross-year individual file instead of the “[Year] Sequence Number” for merging purposes. Page 3 (https://psidonline.isr.umich.edu/Guide/FileStructure.pdf) includes a table of the correct variables for matching single-year family files with the cross-year individual file.

By matching the file with the interview numbers (er33801 in 2005 and er34301 in 2015) you do get different sample sizes because the samples include more non-response cases. However, you could also remove these by dropping cases with a value of "0" for the sequence numbers (er33802 in 2005 and er34302 in 2015). 